### PR TITLE
feat: 記事冒頭を動画，概要，画像の順に変更

### DIFF
--- a/all_collections/_posts/2021-11-05-gravity-lost.md
+++ b/all_collections/_posts/2021-11-05-gravity-lost.md
@@ -7,16 +7,16 @@ thumbnail: gravity-lost-thumbnail
 # youtube: youtube link for embedding
 ---
 
+記憶喪失のロボット「ラヴィ」を操作し，重力反転能力を駆使して記憶チップを回収する3Dアクションゲームです．
+ゲーム制作サークルの新入生プロジェクト（初心者同士でチームを組んで制作する定期活動）の作品です．
+私にとっても，初めてのUnity開発，初めてのチーム制作（GitHub活用），初めての大学祭出展となりました．
+
 ![{{page.title}}]({{site.baseurl}}/assets/images/gravity-lost-thumbnail.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/gravity-lost-tutorial-1.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/gravity-lost-tutorial-2.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/gravity-lost-stage1-1.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/gravity-lost-stage1-2.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/gravity-lost-stage1-3.webp)
-
-記憶喪失のロボット「ラヴィ」を操作し，重力反転能力を駆使して記憶チップを回収する3Dアクションゲームです．
-ゲーム制作サークルの新入生プロジェクト（初心者同士でチームを組んで制作する定期活動）の作品です．
-私にとっても，初めてのUnity開発，初めてのチーム制作（GitHub活用），初めての大学祭出展となりました．
 
 ## Links
 

--- a/all_collections/_posts/2022-10-29-lamp.md
+++ b/all_collections/_posts/2022-10-29-lamp.md
@@ -7,12 +7,6 @@ thumbnail: lamp-thumbnail
 # youtube: youtube link for embedding
 ---
 
-![{{page.title}}]({{site.baseurl}}/assets/images/lamp-thumbnail.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/lamp-info.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/lamp-clear.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/lamp-achievement-level.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/lamp-achievement-click.webp)
-
 クリック操作で全てのランプを点灯させるパズルゲームです．
 ランプをクリックすると，自身とその上下左右のランプの点灯状況が一緒に反転します．
 初めてほぼ自分1人で作り上げたUnityゲームです．
@@ -20,6 +14,12 @@ thumbnail: lamp-thumbnail
 初心者なりに，オブジェクト指向を意識してクラスを設計しました．
 また，少しでも長く飽きずにプレイしてもらうために，クリアしたレベルとクリック回数に応じた実績機能を実装しました．
 2022年度大学祭にて初公開し，展示・配布しました．
+
+![{{page.title}}]({{site.baseurl}}/assets/images/lamp-thumbnail.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/lamp-info.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/lamp-clear.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/lamp-achievement-level.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/lamp-achievement-click.webp)
 
 ## Links
 

--- a/all_collections/_posts/2023-10-28-slash-and-bash.md
+++ b/all_collections/_posts/2023-10-28-slash-and-bash.md
@@ -7,16 +7,16 @@ thumbnail: slaba-thumbnail
 youtube: https://www.youtube.com/embed/D4ZSq_XLCWg?si=p3vVYMA6ik_8XmGH
 ---
 
+ランダムな3桁の数字を推理するゲームです．
+斬撃エフェクトはBlenderとShader Graphで作成しました．
+ヒントが明らかになるにつれて正解候補が絞られていく様子をキューブで可視化しています．
+実機デバッグ用に隠しコマンドを実装しました．
+
 ![{{page.title}}]({{site.baseurl}}/assets/images/slaba-thumbnail.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/slaba-icon.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/slaba-menu.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/slaba-1s0b.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/slaba-0s2b.webp)
-
-ランダムな3桁の数字を推理するゲームです．
-斬撃エフェクトはBlenderとShader Graphで作成しました．
-ヒントが明らかになるにつれて正解候補が絞られていく様子をキューブで可視化しています．
-実機デバッグ用に隠しコマンドを実装しました．
 
 ## Links
 

--- a/all_collections/_posts/2023-10-28-su-ika-game.md
+++ b/all_collections/_posts/2023-10-28-su-ika-game.md
@@ -7,15 +7,15 @@ thumbnail: su-ika-game-thumbnail
 youtube: https://www.youtube.com/embed/v7bXrkjWiv4?si=T8CIxtBuWUfxh8Tp
 ---
 
-![{{page.title}}]({{site.baseurl}}/assets/images/su-ika-game-thumbnail.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/su-ika-game-flyer.webp)
-
 サークル活動として制作した，イカとイカをくっつけて酸っぱくしていくパズルゲームです．
 落ち物の形状が球ではないため，オマージュ元のあのゲームとはまた違った独特なゲーム性が生まれました．
 サークル内製のバックエンドシステムを利用し，オンラインランキング機能を実装しています．
 2023年の大学祭で初公開され，2日間でのべ350回プレイされました！
 展示との親和性と一部からの根強い人気からプレイ数を伸ばし続け，2025年8月7日に通算900プレイを突破しました．  
 （バグの発見によりランキングがとんでもないことになっていますが，通常プレイには支障ありません．時間がかかるかもしれませんが，修正したいと考えています．）
+
+![{{page.title}}]({{site.baseurl}}/assets/images/su-ika-game-thumbnail.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/su-ika-game-flyer.webp)
 
 ## Links
 

--- a/all_collections/_posts/2024-07-21-procranking-unity-sdk.md
+++ b/all_collections/_posts/2024-07-21-procranking-unity-sdk.md
@@ -6,12 +6,12 @@ categories: ["SDK", "Unity Package"]
 thumbnail: prus-thumbnail
 ---
 
-![{{page.title}}]({{site.baseurl}}/assets/images/prus-thumbnail.webp)
-
 ProcRankingのAPIを簡単に扱うためのUnity向けSDKです．（ProcRankingとは，部室サーバーへデータを読み書きするためのサークル内製バックエンドシステムのことです．）
 略称はPRUS（プルース）です．
 サークルメンバーのみに向け，Unity Package Manager上に公開しています．
 [すイカゲーム]({{site.baseurl}}/works/su-ika-game)を含む，オンラインランキング機能を持つUnityゲームたちの開発に貢献しました．
+
+![{{page.title}}]({{site.baseurl}}/assets/images/prus-thumbnail.webp)
 
 ## Source Code
 

--- a/all_collections/_posts/2024-10-22-grandioso.md
+++ b/all_collections/_posts/2024-10-22-grandioso.md
@@ -7,17 +7,17 @@ thumbnail: grandioso-music-select
 youtube: https://www.youtube.com/embed/HUOLcto7V9o?si=1Iysy85TDgZ7QKMw
 ---
 
-![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-music-select.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-title-screen.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-mode-select.webp)
-![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-gallery.webp)
-
 レーンを移動できることが特徴の，ノーツをさばいて敵を倒すリズムゲームです．
 RPGテイストのシナリオを楽しめるノベルゲームパートもあります．
 私が所属する大学のゲーム制作サークルと，他大学のゲーム音楽サークルとの総勢27名による大規模なコラボ作品となっています．
 私はサブとなるゲームシーンのプログラムを担当しました．
 
 2025年4月に，約4か月ぶりとなるアップデートを配信しました！楽曲追加に伴い楽曲リストUIが画面に収まりきらなくなったため，スクロール機構を追加しました．
+
+![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-music-select.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-title-screen.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-mode-select.webp)
+![{{page.title}}]({{site.baseurl}}/assets/images/grandioso-gallery.webp)
 
 ## Links
 

--- a/all_collections/_posts/2025-03-06-neck-stretching-xr.md
+++ b/all_collections/_posts/2025-03-06-neck-stretching-xr.md
@@ -7,11 +7,11 @@ thumbnail: neck-stretching-xr-thumbnail
 # youtube: youtube link for embedding
 ---
 
-![{{page.title}}]({{site.baseurl}}/assets/images/neck-stretching-xr-thumbnail.webp)
-
 > 本研究では，バーチャルスクリーンを空間内で移動させることにより，頭部の回転を促し，作業を中断させることなく頸部（首）のストレッチングを誘導する手法を提案する．本手法では，ユーザが注視しているスクリーンを，ユーザとの距離を保ちながら，頭部のヨー・ピッチ・ロール方向への一定量の回転を促すように移動させることにより，対応する筋肉の伸長を誘導し，凝りの緩和を支援する．
 
 学部卒業研究として取り組んだ研究です．先輩の研究（提案や設計議論）を引き継ぎ，システムの改良・ユーザスタディの実施・結果の統計分析を担当しました．また，研究成果の一部を再構築して論文にまとめ，[第30回日本VR学会大会](https://conference.vrsj.org/ac2025/index.html)で発表しました．国際学会へも投稿しており，査読中です（2025年10月現在）．
+
+![{{page.title}}]({{site.baseurl}}/assets/images/neck-stretching-xr-thumbnail.webp)
 
 ## Links
 

--- a/all_collections/_posts/2025-08-03-twilight-code.md
+++ b/all_collections/_posts/2025-08-03-twilight-code.md
@@ -7,12 +7,12 @@ thumbnail: twilight-code-thumbnail
 # youtube: youtube link for embedding
 ---
 
-![{{page.title}}]({{site.baseurl}}/assets/images/twilight-code-thumbnail.webp)
-
 近未来の東京を舞台にしたポストアポカリプス3Dアクションアドベンチャーゲームです．
 10名のチームで制作しており，私はUI周りの実装をお手伝いさせていただいています．
 [東京ゲームダンジョン9](https://gamedungeon.jp/events/tokyo9)にてデモ版を公開しました．
 完成に向けてまだ鋭意制作中の段階です．
+
+![{{page.title}}]({{site.baseurl}}/assets/images/twilight-code-thumbnail.webp)
 
 ## Links
 

--- a/all_collections/_posts/2025-08-31-spreadink.md
+++ b/all_collections/_posts/2025-08-31-spreadink.md
@@ -7,12 +7,14 @@ thumbnail: spreadink-thumbnail
 # youtube: youtube link for embedding
 ---
 
+インクのひろがりで色を塗り、お題の割合を目指すパズルゲームです．
+[プロトスプリントリーグ](https://www.cyberagent.co.jp/careers/students/event/detail/id=31568)（ハッカソンイベント）で制作し，8チームの中で最優秀賞をいただきました．
+初対面の3人チームで，1週間+2日で完成させるという初の試みの中，ゲームとして面白いものを作ることができました．
+
 ![{{page.title}}]({{site.baseurl}}/assets/images/spreadink-thumbnail.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/spreadink-level-select.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/spreadink-ingame.webp)
 ![{{page.title}}]({{site.baseurl}}/assets/images/spreadink-result.webp)
-
-インクのひろがりで色を塗り、お題の割合を目指すパズルゲームです．[プロトスプリントリーグ](https://www.cyberagent.co.jp/careers/students/event/detail/id=31568)（ハッカソンイベント）で制作し，8チームの中で最優秀賞をいただきました．初対面の3人チームで，1週間+2日で完成させるという初の試みの中，ゲームとして面白いものを作ることができました．
 
 <!-- ## Links
 

--- a/all_collections/_posts/2025-09-17-he-ad.md
+++ b/all_collections/_posts/2025-09-17-he-ad.md
@@ -7,15 +7,12 @@ thumbnail: he-ad-thumbnail
 youtube: [https://www.youtube.com/embed/VBYJLJ1BOpA?si=RdXB7uYpYAx56mWl, https://www.youtube.com/embed/nrwkAutQN8A?si=jZepmgg-civYSdro]
 ---
 
-<!-- タイトルに|が入っているためそのままだとmarkdown tableになってしまう -->
-{% assign clean_title = page.title | replace: "|", " " %}
-![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-thumbnail.webp)
-![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-cut-before.webp)
-![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-cut-after.webp)
-![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-vision.webp)
-![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-recover.webp)
-
-[IVRC2025](https://ivrc.net/2025/)に投稿したVR体験作品です．（IVRCとは，学生を中心としたチームでインタラクティブ作品を企画・制作するチャレンジの大会です．）体験者は，頭が真っ二つに斬られたときの感覚を視覚・触覚・聴覚で安全かつ没入的に体験することができます．また，斬られた頭を自らの手でもとに戻すことができます．SEED STAGE（予選大会）にて観客賞，Unity賞，CRI・ミドルウェア賞を受賞しました．話し合いの中で考え抜いた事項をうまく形にして，体験者の心に残る斬新なUXを創出できたと考えています．
+[IVRC2025](https://ivrc.net/2025/)に投稿したVR体験作品です．
+（IVRCとは，学生を中心としたチームでインタラクティブ作品を企画・制作するチャレンジの大会です．）
+体験者は，頭が真っ二つに斬られたときの感覚を視覚・触覚・聴覚で安全かつ没入的に体験することができます．
+また，斬られた頭を自らの手でもとに戻すことができます．
+SEED STAGE（予選大会）にて観客賞，Unity賞，CRI・ミドルウェア賞を受賞しました．
+話し合いの中で考え抜いた事項をうまく形にして，体験者の心に残る斬新なUXを創出できたと考えています．
 
 - [書類審査](https://ivrc.net/2025/release1/)
   - 通過（20/96作品）
@@ -25,6 +22,14 @@ youtube: [https://www.youtube.com/embed/VBYJLJ1BOpA?si=RdXB7uYpYAx56mWl, https:/
   - Unity賞
   - CRI・ミドルウェア賞
 - LEAP STAGE（決勝大会 ＠[サイエンスアゴラ2025](https://www.jst.go.jp/sis/scienceagora/2025/index.html)）に出展予定
+
+<!-- タイトルに|が入っているためそのままだとmarkdown tableになってしまう -->
+{% assign clean_title = page.title | replace: "|", " " %}
+![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-thumbnail.webp)
+![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-cut-before.webp)
+![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-cut-after.webp)
+![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-vision.webp)
+![{{clean_title}}]({{site.baseurl}}/assets/images/he-ad-recover.webp)
 
 ## Links
 


### PR DESCRIPTION
画像はHomeで見てるし，今の実装だと結構幅取ってしまうので奥に追いやる
多分一番重要なのは概要文なので最初に置く

htmlテンプレを用いている都合上，Youtubeをcontentの中に入れるのはめんどいため動画は概要文よりも上に置かれることにしておく