### PR TITLE
fix: デジタル名刺ページにtitleを追加

### DIFF
--- a/digital-business-card.md
+++ b/digital-business-card.md
@@ -1,4 +1,5 @@
 ---
+title: デジタル名刺
 layout: digital-business-card
 ---
 


### PR DESCRIPTION
ページの表示名が「サイト名 | ページタイトル」のため必要